### PR TITLE
Change detection method of preference values

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@
 DR_CTL="${BASEURL}index.php?/module/inventory/"
 
 # Find out where the munki directory is to set accordingly.
-munki_install_dir=$(/usr/bin/python -c 'import CoreFoundation; print CoreFoundation.CFPreferencesCopyAppValue("ManagedInstallDir", "ManagedInstalls")')
+munki_install_dir=$(osascript -l JavaScript -e "ObjC.import('Foundation'); ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('ManagedInstalls').objectForKey('ManagedInstallDir'))")
 munki_install_dir=$(echo ${munki_install_dir} | sed 's/\/$//')
 
 # Get the scripts in the proper directories


### PR DESCRIPTION
System Python is removed as of macOS 12.3 so pathing to /usr/bin/python is no longer reliable.

This change alters the method for detecting the `ManagedInstallDir` key of `ManagedInstalls` but still uses the NSPreferences model so wherever the preference is set the highest priority location (Managed Preferences, OS Library/Preferences, root Library/Preferences, User Library/Preferences, etc.) will return the value.